### PR TITLE
Replace AccelStepper with Faster stepper library and FastAccelStepper 

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -59,10 +59,10 @@
 */
 #define USES_STEPPER // if a stepper is not used, a DC motor is assumed
 #ifdef USES_STEPPER
-    #define MAX_SPEED 30000 // in steps per second
-    #define ACCELERATION 5000
-    #define DEFAULT_SPEED 30000 // default stepper speed in steps per second
-    #define SPEED_INC 100 // speed increment size in steps per second
+    #define STEPS_PER_MM 650 // how many steps the stepper takes to pull 1mm of filament
+    #define MAX_SPEED 300 // in mm/s
+    #define DEFAULT_SPEED 5 // default stepper speed in mm/s
+    #define SPEED_INC 0.5 // speed increment size in steps per second
 #else
     #define USES_PWM_MOTOR
     #define MAX_SPEED 255 // PWM max. Almost always 256. 

--- a/configuration.h
+++ b/configuration.h
@@ -70,6 +70,21 @@
     #define MAX_SPEED 300 // in mm/s
     #define DEFAULT_SPEED 5 // default stepper speed in mm/s
     #define SPEED_INC 0.5 // speed increment size in steps per second
+
+    /* FastAccelStepper Library*/
+    // Some boards are supported by the FastAccelStepper library,
+    // which runs the stepper in an interrupt and has a far higher
+    // max speed. 
+    // If your chipset is supported, you should enable this. You can check
+    // at the repo:
+    // https://github.com/gin66/FastAccelStepper
+    // NOTE: mm/s speed hasn't been added yet
+    #define USE_FASTACCELSTEPPER_LIBRARY // uncomment to enable
+
+    #ifdef USE_FASTACCELSTEPPER_LIBRARY
+      #define ACCELERATION 5000
+    #endif
+    
 #else
     #define USES_PWM_MOTOR
     #define MAX_SPEED 255 // PWM max. Almost always 256. 

--- a/petinator.ino
+++ b/petinator.ino
@@ -13,11 +13,13 @@
 * - https://github.com/aamott/petinator
 *
 *****************************************************/
+#include "configuration.h"
 
 #include <FastPID.h>
 #include <thermistor.h>
 #ifdef USE_FASTACCELSTEPPER_LIBRARY
   #include <FastAccelStepper.h>
+  // #include "AVRStepperPins.h" // Only required for AVR controllers
 #else
   #include "stepper.h"
 #endif
@@ -33,8 +35,6 @@
 #else
 #include <hd44780ioClass/hd44780_pinIO.h>  // Arduino pin i/o class header
 #endif
-
-#include "configuration.h"
 
 /****************************************
  * Thermistor

--- a/petinator.ino
+++ b/petinator.ino
@@ -17,6 +17,7 @@
 #include <AutoPID.h>
 #include <thermistor.h>
 #include <AccelStepper.h>
+#include "stepper.h"
 #include <ezButton.h>
 #include <EEPROM.h>
 #include "fastMenu.cpp"

--- a/stepper.h
+++ b/stepper.h
@@ -6,7 +6,7 @@ private:
   const int _enable_pin = -1;
   const bool _invert_enable;
   const unsigned int _min_pulse_width;
-  const unsigned int _steps_per_mm;
+  const unsigned int _steps_per_mm = 0;
 
   // step tracking
   unsigned long _micros_per_step = 0;

--- a/stepper.h
+++ b/stepper.h
@@ -70,6 +70,7 @@ public:
   /// @brief Sets motor speed in millimeters per second. Will not move the motor if steps per mm is not set.
   void set_speed_mms(float millimeters_per_second) {
     if (millimeters_per_second == 0) {
+      stop();
       return;
     }
 

--- a/stepper.h
+++ b/stepper.h
@@ -27,9 +27,10 @@ public:
   /// @param step_pin Driver step pin.
   /// @param direction_pin Driver direction pin.
   /// @param enable_pin Driver enable pin. Less than 0 for no enable pin.
-  /// @param min_pulse_width Minimum number of microseconds a pulse width can take.
-  Stepper(int step_pin, int direction_pin, int enable_pin = -1, int min_pulse_width = 1)
-    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _min_pulse_width(min_pulse_width) {
+  /// @param invert_enable_pin Whether to invert the enable pin. Disabled will be HIGH, Enabled will be LOW. Default false; 
+  /// @param min_pulse_width Minimum number of microseconds a pulse width can take. Default 1.
+  Stepper(int step_pin, int direction_pin, int enable_pin = -1, bool invert_enable_pin = false, int min_pulse_width = 1)
+    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable_pin(invert_enable_pin), _min_pulse_width(min_pulse_width) {
     pinMode(step_pin, OUTPUT);
     pinMode(direction_pin, OUTPUT);
 

--- a/stepper.h
+++ b/stepper.h
@@ -114,6 +114,7 @@ public:
 
 
   /// @brief Stop motor movements
+  /// Sets the speed to 0 and stops movement
   void stop() {
     _micros_per_step = 0;
     // _invert_enable will either be false (LOW) or true (HIGH)

--- a/stepper.h
+++ b/stepper.h
@@ -89,7 +89,7 @@ public:
     }
 
     // set stepper direction
-    digitalWrite(_direction_pin, reverse_direction);
+    digitalWrite(_direction_pin, !reverse_direction);
 
     // enable stepper
     if (_enable_pin >= 0) {

--- a/stepper.h
+++ b/stepper.h
@@ -6,6 +6,7 @@ private:
   const int _enable_pin = -1;
   const bool _invert_enable;
   const unsigned int _min_pulse_width;
+  const unsigned int _steps_per_mm;
 
   // step tracking
   unsigned long _micros_per_step = 0;
@@ -28,15 +29,52 @@ public:
   /// @param direction_pin Driver direction pin.
   /// @param enable_pin Driver enable pin. Less than 0 for no enable pin.
   /// @param invert_enable_pin Whether to invert the enable pin. Disabled will be HIGH, Enabled will be LOW. Default false;
+  /// @param steps_per_mm Number of steps to move a mm. If set to 0, speeds in mm/s will be ignored.
   /// @param min_pulse_width Minimum number of microseconds a pulse width can take. Default 1.
-  Stepper(int step_pin, int direction_pin, int enable_pin = -1, bool invert_enable_pin = false, int min_pulse_width = 1)
-    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable(invert_enable_pin), _min_pulse_width(min_pulse_width) {
+  Stepper(int step_pin, int direction_pin, int enable_pin = -1, bool invert_enable_pin = false, int steps_per_mm = 0, int min_pulse_width = 1)
+    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable(invert_enable_pin), _steps_per_mm(steps_per_mm), _min_pulse_width(min_pulse_width) {
     pinMode(step_pin, OUTPUT);
     pinMode(direction_pin, OUTPUT);
 
     if (enable_pin >= 0) {
       pinMode(enable_pin, OUTPUT);
     }
+
+    stop();
+  }
+
+
+  /// @brief get the speed in mm/s
+  unsigned float speed_mms() {
+    // TODO: Just calculate this every time the speed changes and return the variable.
+    // return millimeters_per_second
+    return (float)speed_sps() / _steps_per_mm;
+  }
+
+
+  /// @brief get the speed in steps per second
+  unsigned int speed_sps() {
+    // TODO: Just calculate this every time the speed changes and return the variable.
+    // return steps_per_second
+    return _micros_per_step * 1000000;
+  }
+
+
+  /// @brief return whether the stepper is currently running
+  /// @return (bool) whether the stepper is currently running
+  bool running() {
+    return _micros_per_step;
+  }
+
+
+  /// @brief Sets motor speed in millimeters per second. Will not move the motor if steps per mm is not set.
+  void set_speed_mms(float millimeters_per_second) {
+    if (millimeters_per_second == 0) {
+      return;
+    }
+
+    int steps_per_second = millimeters_per_second * _steps_per_mm;
+    set_speed(steps_per_second);
   }
 
 

--- a/stepper.h
+++ b/stepper.h
@@ -1,0 +1,72 @@
+class Stepper {
+
+private:
+  const unsigned int _step_pin;
+  const unsigned int _direction_pin;
+  const int _enable_pin = -1;
+  const unsigned int _min_pulse_width;
+
+  // step tracking
+  unsigned long _micros_per_step = 0;
+  long _last_step = 0;
+
+  /// @brief Step the motor. Takes at least _min_pulse_width microseconds.
+  inline void step() {
+    digitalWrite(_step_pin, HIGH); // start pulse
+
+    // Delay the minimum allowed pulse width
+    delayMicroseconds(_min_pulse_width);
+    
+    digitalWrite(_step_pin, LOW); // end pulse
+  }
+
+public:
+
+  /// @brief 
+  /// @param step_pin Driver step pin.
+  /// @param direction_pin Driver direction pin.
+  /// @param enable_pin Driver enable pin. Less than 0 for no enable pin.
+  /// @param min_pulse_width Minimum number of microseconds a pulse width can take.
+  Stepper(int step_pin, int direction_pin, int enable_pin = -1, int min_pulse_width = 1)
+    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _min_pulse_width(min_pulse_width) {
+    pinMode(step_pin, OUTPUT);
+    pinMode(direction_pin, OUTPUT);
+
+    if (enable_pin >= 0) {
+        pinMode(enable_pin, OUTPUT);
+    }
+  }
+
+
+  /// @brief Set speed in steps per second
+  /// @param steps_per_second 
+  /// @param reverse_direction Whether to reverse stepper direction. 
+  void set_speed(int steps_per_second, bool reverse_direction = false) {
+    if (steps_per_second > 1000000) {
+        _micros_per_step = 0;
+    } else {
+        _micros_per_step = 1000000 / steps_per_second;
+    }
+
+    // set stepper direction
+    digitalWrite(_direction_pin, reverse_direction);
+  }
+
+
+  /// @brief Check if a step is due. If a step is due, will take at least _min_pulse_width microseconds to run. 
+  void run() {
+    long current_time = micros();
+
+    if ( _micros_per_step != 0 && _last_step + _micros_per_step < current_time) {
+        step();
+    }
+
+    _last_step = micros();
+  }
+
+
+  /// @brief Stop motor movements
+  void stop() {
+    _micros_per_step = 0;
+  }
+};

--- a/stepper.h
+++ b/stepper.h
@@ -4,7 +4,7 @@ private:
   const unsigned int _step_pin;
   const unsigned int _direction_pin;
   const int _enable_pin = -1;
-  bool invert_enable = false;
+  const bool _invert_enable;
   const unsigned int _min_pulse_width;
 
   // step tracking
@@ -30,7 +30,7 @@ public:
   /// @param invert_enable_pin Whether to invert the enable pin. Disabled will be HIGH, Enabled will be LOW. Default false;
   /// @param min_pulse_width Minimum number of microseconds a pulse width can take. Default 1.
   Stepper(int step_pin, int direction_pin, int enable_pin = -1, bool invert_enable_pin = false, int min_pulse_width = 1)
-    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable_pin(invert_enable_pin), _min_pulse_width(min_pulse_width) {
+    : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable(invert_enable_pin), _min_pulse_width(min_pulse_width) {
     pinMode(step_pin, OUTPUT);
     pinMode(direction_pin, OUTPUT);
 
@@ -55,8 +55,8 @@ public:
 
     // enable stepper
     if (_enable_pin >= 0) {
-      // invert_enable will either be false (HIGH) or true (LOW)
-      digitalWrite(_enable_pin, !invert_enable);
+      // _invert_enable will either be false (HIGH) or true (LOW)
+      digitalWrite(_enable_pin, !_invert_enable);
     }
   }
 
@@ -78,7 +78,7 @@ public:
   /// @brief Stop motor movements
   void stop() {
     _micros_per_step = 0;
-    // invert_enable will either be false (LOW) or true (HIGH)
-    digitalWrite(_enable_pin, invert_enable);
+    // _invert_enable will either be false (LOW) or true (HIGH)
+    digitalWrite(_enable_pin, _invert_enable);
   }
 };

--- a/stepper.h
+++ b/stepper.h
@@ -4,6 +4,7 @@ private:
   const unsigned int _step_pin;
   const unsigned int _direction_pin;
   const int _enable_pin = -1;
+  bool invert_enable = false;
   const unsigned int _min_pulse_width;
 
   // step tracking
@@ -50,11 +51,19 @@ public:
 
     // set stepper direction
     digitalWrite(_direction_pin, reverse_direction);
+
+    // enable stepper
+    if (_enable_pin >= 0) {
+        // invert_enable will either be false (HIGH) or true (LOW)
+        digitalWrite(_enable_pin, !invert_enable);
+    }
   }
 
 
   /// @brief Check if a step is due. If a step is due, will take at least _min_pulse_width microseconds to run. 
   void run() {
+    // TODO: add acceleration
+
     long current_time = micros();
 
     if ( _micros_per_step != 0 && _last_step + _micros_per_step < current_time) {
@@ -68,5 +77,7 @@ public:
   /// @brief Stop motor movements
   void stop() {
     _micros_per_step = 0;
+    // invert_enable will either be false (LOW) or true (HIGH)
+    digitalWrite(_enable_pin, invert_enable);
   }
 };

--- a/stepper.h
+++ b/stepper.h
@@ -13,21 +13,21 @@ private:
 
   /// @brief Step the motor. Takes at least _min_pulse_width microseconds.
   inline void step() {
-    digitalWrite(_step_pin, HIGH); // start pulse
+    digitalWrite(_step_pin, HIGH);  // start pulse
 
     // Delay the minimum allowed pulse width
     delayMicroseconds(_min_pulse_width);
-    
-    digitalWrite(_step_pin, LOW); // end pulse
+
+    digitalWrite(_step_pin, LOW);  // end pulse
   }
 
 public:
 
-  /// @brief 
+  /// @brief
   /// @param step_pin Driver step pin.
   /// @param direction_pin Driver direction pin.
   /// @param enable_pin Driver enable pin. Less than 0 for no enable pin.
-  /// @param invert_enable_pin Whether to invert the enable pin. Disabled will be HIGH, Enabled will be LOW. Default false; 
+  /// @param invert_enable_pin Whether to invert the enable pin. Disabled will be HIGH, Enabled will be LOW. Default false;
   /// @param min_pulse_width Minimum number of microseconds a pulse width can take. Default 1.
   Stepper(int step_pin, int direction_pin, int enable_pin = -1, bool invert_enable_pin = false, int min_pulse_width = 1)
     : _step_pin(step_pin), _direction_pin(direction_pin), _enable_pin(enable_pin), _invert_enable_pin(invert_enable_pin), _min_pulse_width(min_pulse_width) {
@@ -35,19 +35,19 @@ public:
     pinMode(direction_pin, OUTPUT);
 
     if (enable_pin >= 0) {
-        pinMode(enable_pin, OUTPUT);
+      pinMode(enable_pin, OUTPUT);
     }
   }
 
 
   /// @brief Set speed in steps per second
-  /// @param steps_per_second 
-  /// @param reverse_direction Whether to reverse stepper direction. 
+  /// @param steps_per_second
+  /// @param reverse_direction Whether to reverse stepper direction.
   void set_speed(int steps_per_second, bool reverse_direction = false) {
     if (steps_per_second > 1000000) {
-        _micros_per_step = 0;
+      _micros_per_step = 0;
     } else {
-        _micros_per_step = 1000000 / steps_per_second;
+      _micros_per_step = 1000000 / steps_per_second;
     }
 
     // set stepper direction
@@ -55,20 +55,20 @@ public:
 
     // enable stepper
     if (_enable_pin >= 0) {
-        // invert_enable will either be false (HIGH) or true (LOW)
-        digitalWrite(_enable_pin, !invert_enable);
+      // invert_enable will either be false (HIGH) or true (LOW)
+      digitalWrite(_enable_pin, !invert_enable);
     }
   }
 
 
-  /// @brief Check if a step is due. If a step is due, will take at least _min_pulse_width microseconds to run. 
+  /// @brief Check if a step is due. If a step is due, will take at least _min_pulse_width microseconds to run.
   void run() {
     // TODO: add acceleration
 
     long current_time = micros();
 
-    if ( _micros_per_step != 0 && _last_step + _micros_per_step < current_time) {
-        step();
+    if (_micros_per_step != 0 && _last_step + _micros_per_step < current_time) {
+      step();
     }
 
     _last_step = micros();

--- a/stepper.h
+++ b/stepper.h
@@ -45,7 +45,7 @@ public:
 
 
   /// @brief get the speed in mm/s
-  unsigned float speed_mms() {
+  float speed_mms() {
     // TODO: Just calculate this every time the speed changes and return the variable.
     // return millimeters_per_second
     return (float)speed_sps() / _steps_per_mm;


### PR DESCRIPTION
Was it tested tested?  
All modes were tested in Wokwi and the new library was thoroughly tested in real life. 

Description  
`AccelStepper` was too slow to be usable. The new library reaches acceptable speeds when in single thread mode. `FastAccelStepper` can be enabled to replace it on supported boards. 